### PR TITLE
Add Typescript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+declare module 'asynchronous-emitter' {
+    
+    import { EventEmitter } from 'events';
+
+    export = AsyncEventEmitter;
+    
+    class AsyncEventEmitter extends EventEmitter {
+        constructor(...args: any[]);
+    
+        emit(type: any, args: any): Promise<void>;
+        emit(type: any, args: any): any;
+    
+    }
+}


### PR DESCRIPTION
In order to use this module in a Typescript project, we need the type definition that can be found in the declaration file. Then, it can be imported like this:
```
import AsyncEventEmitter = require('asynchronous-emitter');
```